### PR TITLE
Updated for Blade 2.0 and Improved

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ path = "src/bin.rs"
 
 [dependencies]
 libc = "0.1.10"
+num-complex = "0.4.6"

--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -11,19 +11,19 @@ pub enum Struct_bladerf { }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub enum bladerf_backend {
-    BLADERF_BACKEND_ANY = 0,    
-    BLADERF_BACKEND_LINUX = 1,  
-    BLADERF_BACKEND_LIBUSB = 2, 
-    BLADERF_BACKEND_CYPRESS = 3, 
-    BLADERF_BACKEND_DUMMY = 100,
+    ANY = 0,    
+    LINUX = 1,  
+    LIBUSB = 2, 
+    CYPRESS = 3, 
+    DUMMY = 100,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub enum bladerf_dev_speed {
-    BLADERF_DEVICE_SPEED_UNKNOWN = 0,
-    BLADERF_DEVICE_SPEED_HIGH = 1,
-    BLADERF_DEVICE_SPEED_SUPER = 2,
+    UNKNOWN = 0,
+    HIGH = 1,
+    SUPER = 2,
 }
 
 #[repr(C)]
@@ -57,24 +57,24 @@ impl Struct_bladerf_devinfo {
 #[repr(C)]
 #[derive(Debug, PartialEq)]
 pub enum bladerf_tuning_mode {
-    BLADERF_TUNING_MODE_INVALID = -1,
-    BLADERF_TUNING_MODE_HOST = 0,
-    BLADERF_TUNING_MODE_FPGA = 1,
+    INVALID = -1,
+    HOST = 0,
+    FPGA = 1,
 }
 
 #[repr(C)]
 #[derive(Debug, PartialEq)]
 pub enum bladerf_loopback {
-    BLADERF_LB_NONE = 0,
-    BLADERF_LB_FIRMWARE = 1,
-    BLADERF_LB_BB_TXLPF_RXVGA2 = 2,
-    BLADERF_LB_BB_TXVGA1_RXVGA2 = 3,
-    BLADERF_LB_BB_TXLPF_RXLPF = 4,
-    BLADERF_LB_BB_TXVGA1_RXLPF = 5,
-    BLADERF_LB_RF_LNA1 = 6,
-    BLADERF_LB_RF_LNA2 = 7,
-    BLADERF_LB_RF_LNA3 = 8,
-    BLADERF_LB_RFIC_BIST = 9,
+    NONE = 0,
+    FIRMWARE = 1,
+    BB_TXLPF_RXVGA2 = 2,
+    BB_TXVGA1_RXVGA2 = 3,
+    BB_TXLPF_RXLPF = 4,
+    BB_TXVGA1_RXLPF = 5,
+    RF_LNA1 = 6,
+    RF_LNA2 = 7,
+    RF_LNA3 = 8,
+    RFIC_BIST = 9,
 }
 
 #[repr(C)]
@@ -94,9 +94,9 @@ impl ::std::default::Default for Struct_bladerf_rational_rate {
 #[repr(C)]
 #[derive(Copy, PartialEq, Debug)]
 pub enum bladerf_sampling {
-    BLADERF_SAMPLING_UNKNOWN = 0,
-    BLADERF_SAMPLING_INTERNAL = 1,
-    BLADERF_SAMPLING_EXTERNAL = 2,
+    UNKNOWN = 0,
+    INTERNAL = 1,
+    EXTERNAL = 2,
 }
 impl ::std::clone::Clone for bladerf_sampling {
     fn clone(&self) -> Self { *self }
@@ -107,18 +107,18 @@ impl ::std::default::Default for bladerf_sampling {
 
 #[repr(C)]
 pub enum bladerf_lna_gain {
-    BLADERF_LNA_GAIN_UNKNOWN = 0,
-    BLADERF_LNA_GAIN_BYPASS = 1,
-    BLADERF_LNA_GAIN_MID = 2,
-    BLADERF_LNA_GAIN_MAX = 3,
+    UNKNOWN = 0,
+    BYPASS = 1,
+    MID = 2,
+    MAX = 3,
 }
 
 #[repr(C)]
 #[derive(Copy)]
 pub enum bladerf_lpf_mode {
-    BLADERF_LPF_NORMAL = 0,
-    BLADERF_LPF_BYPASSED = 1,
-    BLADERF_LPF_DISABLED = 2,
+    NORMAL = 0,
+    BYPASSED = 1,
+    DISABLED = 2,
 }
 impl ::std::clone::Clone for bladerf_lpf_mode {
     fn clone(&self) -> Self { *self }
@@ -127,8 +127,10 @@ impl ::std::clone::Clone for bladerf_lpf_mode {
 #[repr(C)]
 #[derive(Copy)]
 pub enum bladerf_module {
-    BLADERF_MODULE_RX = 0,
-    BLADERF_MODULE_TX = 1,
+    RX0 = 0,
+    TX0 = 1,
+    RX1 = 2,
+    TX1 = 3,
 }
 impl ::std::clone::Clone for bladerf_module {
     fn clone(&self) -> Self { *self }
@@ -136,25 +138,25 @@ impl ::std::clone::Clone for bladerf_module {
 
 #[repr(C)]
 pub enum bladerf_xb {
-    BLADERF_XB_NONE = 0,
-    BLADERF_XB_100 = 1,
-    BLADERF_XB_200 = 2,
+    NONE = 0,
+    XB_100 = 1,
+    XB_200 = 2,
 }
 
 #[repr(C)]
 pub enum bladerf_xb200_filter {
-    BLADERF_XB200_50M = 0,
-    BLADERF_XB200_144M = 1,
-    BLADERF_XB200_222M = 2,
-    BLADERF_XB200_CUSTOM = 3,
-    BLADERF_XB200_AUTO_1DB = 4,
-    BLADERF_XB200_AUTO_3DB = 5,
+    FILTER_50M = 0,
+    FILTER_144M = 1,
+    FILTER_222M = 2,
+    CUSTOM = 3,
+    AUTO_1DB = 4,
+    AUTO_3DB = 5,
 }
 
 #[repr(C)]
 pub enum bladerf_xb200_path {
-    BLADERF_XB200_BYPASS = 0,
-    BLADERF_XB200_MIX = 1,
+    BYPASS = 0,
+    MIX = 1,
 }
 
 #[repr(C)]
@@ -175,45 +177,48 @@ impl ::std::default::Default for Struct_bladerf_quick_tune {
 
 #[repr(C)]
 pub enum bladerf_cal_module {
-    BLADERF_DC_CAL_LPF_TUNING = 0,
-    BLADERF_DC_CAL_TX_LPF = 1,
-    BLADERF_DC_CAL_RX_LPF = 2,
-    BLADERF_DC_CAL_RXVGA2 = 3,
+    LPF_TUNING = 0,
+    TX_LPF = 1,
+    RX_LPF = 2,
+    RXVGA2 = 3,
 }
 
 #[repr(C)]
 pub enum bladerf_correction {
-    BLADERF_CORR_LMS_DCOFF_I = 0,
-    BLADERF_CORR_LMS_DCOFF_Q = 1,
-    BLADERF_CORR_FPGA_PHASE = 2,
-    BLADERF_CORR_FPGA_GAIN = 3,
+    LMS_DCOFF_I = 0,
+    LMS_DCOFF_Q = 1,
+    FPGA_PHASE = 2,
+    FPGA_GAIN = 3,
 }
 
 #[repr(C)]
 pub enum bladerf_format {
-    BLADERF_FORMAT_SC16_Q11 = 0,
-    BLADERF_FORMAT_SC16_Q11_META = 1,
+    SC16_Q11 = 0,
+    SC16_Q11_META = 1,
+    PACKET_META = 2,
+    SC8_Q7 = 3,
+    SC8_Q7_META = 4,
 }
 
 pub enum bladerf_error {
-    BLADERF_ERR_UNEXPECTED  = -1,
-    BLADERF_ERR_RANGE       = -2,
-    BLADERF_ERR_INVAL       = -3,
-    BLADERF_ERR_MEM         = -4,
-    BLADERF_ERR_IO          = -5,
-    BLADERF_ERR_TIMEOUT     = -6,
-    BLADERF_ERR_NODEV       = -7,
-    BLADERF_ERR_UNSUPPORTED = -8,
-    BLADERF_ERR_MISALIGNED  = -9,
-    BLADERF_ERR_CHECKSUM    = -10,
-    BLADERF_ERR_NO_FILE     = -11,
-    BLADERF_ERR_UPDATE_FPGA = -12,
-    BLADERF_ERR_UPDATE_FW   = -13,
-    BLADERF_ERR_TIME_PAST   = -14,
-    BLADERF_ERR_QUEUE_FULL  = -15,
-    BLADERF_ERR_FPGA_OP     = -16,
-    BLADERF_ERR_PERMISSION  = -17,
-    BLADERF_ERR_WOULD_BLOCK = -18,
+    UNEXPECTED  = -1,
+    RANGE       = -2,
+    INVAL       = -3,
+    MEM         = -4,
+    IO          = -5,
+    TIMEOUT     = -6,
+    NODEV       = -7,
+    UNSUPPORTED = -8,
+    MISALIGNED  = -9,
+    CHECKSUM    = -10,
+    NO_FILE     = -11,
+    UPDATE_FPGA = -12,
+    UPDATE_FW   = -13,
+    TIME_PAST   = -14,
+    QUEUE_FULL  = -15,
+    FPGA_OP     = -16,
+    PERMISSION  = -17,
+    WOULD_BLOCK = -18,
 }
 
 #[repr(C)]
@@ -259,35 +264,44 @@ impl ::std::default::Default for Struct_bladerf_version {
 
 #[repr(C)]
 pub enum bladerf_fpga_size {
-    BLADERF_FPGA_UNKNOWN = 0,
-    BLADERF_FPGA_40KLE = 40,
-    BLADERF_FPGA_115KLE = 115,
+    UNKNOWN = 0,
+    FPGA_40KLE = 40,
+    FPGA_115KLE = 115,
 }
 
 #[repr(C)]
 pub enum bladerf_log_level {
-    BLADERF_LOG_LEVEL_VERBOSE = 0,
-    BLADERF_LOG_LEVEL_DEBUG = 1,
-    BLADERF_LOG_LEVEL_INFO = 2,
-    BLADERF_LOG_LEVEL_WARNING = 3,
-    BLADERF_LOG_LEVEL_ERROR = 4,
-    BLADERF_LOG_LEVEL_CRITICAL = 5,
-    BLADERF_LOG_LEVEL_SILENT = 6,
+    VERBOSE = 0,
+    DEBUG = 1,
+    INFO = 2,
+    WARNING = 3,
+    ERROR = 4,
+    CRITICAL = 5,
+    SILENT = 6,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub enum bladerf_channel_layout {
+    RX_X1 = 0,
+    TX_X1 = 1,
+    RX_X2 = 2,
+    TX_X2 = 3,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub enum bladerf_image_type {
-    BLADERF_IMAGE_TYPE_INVALID= -1,
-    BLADERF_IMAGE_TYPE_RAW = 0,
-    BLADERF_IMAGE_TYPE_FIRMWARE = 1,
-    BLADERF_IMAGE_TYPE_FPGA_40KLE = 2,
-    BLADERF_IMAGE_TYPE_FPGA_115KLE = 3,
-    BLADERF_IMAGE_TYPE_CALIBRATION = 4,
-    BLADERF_IMAGE_TYPE_RX_DC_CAL = 5,
-    BLADERF_IMAGE_TYPE_TX_DC_CAL = 6,
-    BLADERF_IMAGE_TYPE_RX_IQ_CAL = 7,
-    BLADERF_IMAGE_TYPE_TX_IQ_CAL = 8,
+    INVALID= -1,
+    RAW = 0,
+    FIRMWARE = 1,
+    FPGA_40KLE = 2,
+    FPGA_115KLE = 3,
+    CALIBRATION = 4,
+    RX_DC_CAL = 5,
+    TX_DC_CAL = 6,
+    RX_IQ_CAL = 7,
+    TX_IQ_CAL = 8,
 }
 
 #[repr(C)]
@@ -507,7 +521,8 @@ extern "C" {
                                       timeout: *mut ::libc::c_uint)
      -> ::libc::c_int;
     pub fn bladerf_sync_config(dev: *mut Struct_bladerf,
-                               module: bladerf_module, format: bladerf_format,
+                               layout: bladerf_channel_layout,
+                               format: bladerf_format,
                                num_buffers: ::libc::c_uint,
                                buffer_size: ::libc::c_uint,
                                num_transfers: ::libc::c_uint,

--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -65,6 +65,7 @@ pub enum bladerf_tuning_mode {
 #[repr(C)]
 #[derive(Debug, PartialEq)]
 pub enum bladerf_loopback {
+    BLADERF_LB_NONE = 0,
     BLADERF_LB_FIRMWARE = 1,
     BLADERF_LB_BB_TXLPF_RXVGA2 = 2,
     BLADERF_LB_BB_TXVGA1_RXVGA2 = 3,
@@ -73,7 +74,7 @@ pub enum bladerf_loopback {
     BLADERF_LB_RF_LNA1 = 6,
     BLADERF_LB_RF_LNA2 = 7,
     BLADERF_LB_RF_LNA3 = 8,
-    BLADERF_LB_NONE = 9,
+    BLADERF_LB_RFIC_BIST = 9,
 }
 
 #[repr(C)]
@@ -91,7 +92,7 @@ impl ::std::default::Default for Struct_bladerf_rational_rate {
 }
 
 #[repr(C)]
-#[derive(Copy, PartialEq)]
+#[derive(Copy, PartialEq, Debug)]
 pub enum bladerf_sampling {
     BLADERF_SAMPLING_UNKNOWN = 0,
     BLADERF_SAMPLING_INTERNAL = 1,
@@ -333,14 +334,14 @@ impl ::std::default::Default for Struct_bladerf_lms_dc_cals {
 
 #[link(name = "bladeRF")]
 extern "C" {
-    pub fn bladerf_get_device_list(devices: &*mut Struct_bladerf_devinfo) 
+    pub fn bladerf_get_device_list(devices: *mut *mut Struct_bladerf_devinfo) 
     -> libc::c_int;
-    pub fn bladerf_free_device_list(devices: *mut Struct_bladerf_devinfo)
+    pub fn bladerf_free_device_list(devices: *const Struct_bladerf_devinfo)
     -> ();
-    pub fn bladerf_open_with_devinfo(device: &*mut Struct_bladerf,
+    pub fn bladerf_open_with_devinfo(device: *mut *mut Struct_bladerf,
                                      devinfo: *const Struct_bladerf_devinfo)
      -> ::libc::c_int;
-    pub fn bladerf_open(device:  &*mut Struct_bladerf,
+    pub fn bladerf_open(device:  *mut *mut Struct_bladerf,
                         device_identifier: *const ::libc::c_char)
      -> ::libc::c_int;
     pub fn bladerf_close(device: *mut Struct_bladerf) -> ();
@@ -440,7 +441,7 @@ extern "C" {
                                frequency: ::libc::c_uint) -> ::libc::c_int;
     pub fn bladerf_set_frequency(dev: *mut Struct_bladerf,
                                  module: bladerf_module,
-                                 frequency: ::libc::c_uint) -> ::libc::c_int;
+                                 frequency: u64) -> ::libc::c_int;
     pub fn bladerf_schedule_retune(dev: *mut Struct_bladerf,
                                    module: bladerf_module,
                                    timestamp: uint64_t,
@@ -452,7 +453,7 @@ extern "C" {
      -> ::libc::c_int;
     pub fn bladerf_get_frequency(dev: *mut Struct_bladerf,
                                  module: bladerf_module,
-                                 frequency: *mut ::libc::c_uint)
+                                 frequency: *mut u64)
      -> ::libc::c_int;
     pub fn bladerf_get_quick_tune(dev: *mut Struct_bladerf,
                                   module: bladerf_module,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 extern crate libc;
+extern crate num_complex;
 
 use std::*;
 use std::mem::*;
+
+use num_complex::Complex;
 
 #[allow(dead_code, non_camel_case_types)]
 mod bladerf;
@@ -43,14 +46,6 @@ pub struct BladeRFModuleConfig {
 pub struct BladeRFConfig {
 	pub tx: BladeRFModuleConfig,
 	pub rx: BladeRFModuleConfig
-}
-
-#[repr(C)]
-#[repr(packed)]
-#[derive(Copy, Clone)]
-pub struct iq {
-	pub i: i16,
-	pub q: i16
 }
 
 // BladeRF device object
@@ -646,7 +641,7 @@ impl BladeRFDevice {
 		}
 	}
 
-	pub fn sync_tx(&self, data: &Vec<iq>, meta: Option<Struct_bladerf_metadata>, stream_timeout: u32)
+	pub fn sync_tx(&self, data: &Vec<Complex<i16>>, meta: Option<Struct_bladerf_metadata>, stream_timeout: u32)
 		       -> Result<isize, isize> {
 
 		// Handle optional meta argument
@@ -668,7 +663,7 @@ impl BladeRFDevice {
 		}
 	}
 
-	pub fn sync_rx(&self, data: &mut Vec<iq>, meta: Option<Struct_bladerf_metadata>, stream_timeout: u32)
+	pub fn sync_rx(&self, data: &mut Vec<Complex<i16>>, meta: Option<Struct_bladerf_metadata>, stream_timeout: u32)
 		       -> Result<isize, isize> {
 
 		// Handle optional meta argument

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate libc;
 
 use std::*;
+use std::mem::*;
 
 #[allow(dead_code, non_camel_case_types)]
 mod bladerf;
@@ -26,7 +27,7 @@ macro_rules! handle_res {
 
 // BladeRF module config object
 pub struct BladeRFModuleConfig {
-	pub frequency: u32,
+	pub frequency: u64,
 	pub sample_rate: u32,
 	pub bandwidth: u32,
 	pub lna_gain: bladerf_lna_gain,
@@ -49,7 +50,15 @@ pub struct iq {
 
 // BladeRF device object
 pub struct BladeRFDevice {
-   device: *mut Struct_bladerf
+	device: MaybeUninit<*mut Struct_bladerf>,
+}
+
+impl Drop for BladeRFDevice {
+	fn drop(&mut self) {
+		unsafe {
+			bladerf_close(self.device.assume_init())
+		}
+	}
 }
 
 
@@ -58,15 +67,15 @@ pub struct BladeRFDevice {
 pub fn get_device_list() -> Result<Vec<Struct_bladerf_devinfo>, isize> {
 
 	unsafe{ 
-		let devices: *mut Struct_bladerf_devinfo = mem::uninitialized();
+		let mut devices = MaybeUninit::<*mut Struct_bladerf_devinfo>::uninit();
 
-		let n = bladerf_get_device_list(&devices) as isize;
+		let n = bladerf_get_device_list(devices.as_mut_ptr()) as isize;
 
 		// Catch bladerf function errors
 		if n > 0 {
 
 			// Cast array to slice and create a safe array to return
-			let device_slice = std::slice::from_raw_parts(devices, n as usize);
+			let device_slice = std::slice::from_raw_parts(*devices.as_ptr(), n as usize);
 			let mut safe_device_list: Vec<Struct_bladerf_devinfo> = Vec::new();
 
 			for i in 0..n {
@@ -74,7 +83,7 @@ pub fn get_device_list() -> Result<Vec<Struct_bladerf_devinfo>, isize> {
 				//Safe if this is a copy, unsafe if it is not?
 				safe_device_list.push(local_device);
 			}
-			bladerf_free_device_list(devices);
+			bladerf_free_device_list(*devices.as_ptr());
 			
 			// Return rust save device info array
 			Ok(safe_device_list)
@@ -103,9 +112,9 @@ pub fn open(identifier: Option<String>) -> Result<BladeRFDevice, isize> {
 			}
 		};
 
-		let bladerf_device = BladeRFDevice { device: mem::uninitialized() };
+		let mut bladerf_device = BladeRFDevice { device: MaybeUninit::uninit() };
 
-		let res = bladerf_open(&(bladerf_device.device), id_ptr);
+		let res = bladerf_open(bladerf_device.device.as_mut_ptr(), id_ptr);
 
 		handle_res!(res, bladerf_device);
 	}
@@ -116,9 +125,9 @@ pub fn open_with_devinfo(devinfo: &Struct_bladerf_devinfo) -> Result<BladeRFDevi
 	let devinfo_ptr: *const Struct_bladerf_devinfo = devinfo as *const Struct_bladerf_devinfo;
 
 	unsafe {
-		let bladerf_device = BladeRFDevice { device: mem::uninitialized() };
+		let mut bladerf_device = BladeRFDevice { device: MaybeUninit::uninit() };
 
-		let res = bladerf_open_with_devinfo(&(bladerf_device.device), devinfo_ptr);
+		let res = bladerf_open_with_devinfo(bladerf_device.device.as_mut_ptr(), devinfo_ptr);
 
 		handle_res!(res, bladerf_device);
 	}
@@ -138,7 +147,7 @@ impl BladeRFDevice {
 			let serial_data : Vec<::libc::c_char> = vec![0; 33];
 
 			// Call underlying c method
-			let res = bladerf_get_serial(self.device, serial_data.as_ptr());
+			let res = bladerf_get_serial(self.device.assume_init(), serial_data.as_ptr());
 
 			if res >= 0 {
 				// Map ::libc::c_char back to u8 as required for string manipulation
@@ -159,7 +168,7 @@ impl BladeRFDevice {
 		let mut fpga_size: bladerf_fpga_size = bladerf_fpga_size::BLADERF_FPGA_UNKNOWN;
 
 		unsafe {
-			let res = bladerf_get_fpga_size(self.device, &mut fpga_size as *mut bladerf_fpga_size);
+			let res = bladerf_get_fpga_size(self.device.assume_init(), &mut fpga_size);
 
 			handle_res!(res, fpga_size);
 		}
@@ -167,9 +176,17 @@ impl BladeRFDevice {
 
 	pub fn fw_version(&self) -> Result<Struct_bladerf_version, isize> {
 		unsafe {
-			let mut version: Struct_bladerf_version = mem::uninitialized();
+			let mut version = Struct_bladerf_version {
+				major: 0,
+				minor: 0,
+				patch: 0,
+				describe: 0 as *const i8,
+			};
 
-			let res = bladerf_fw_version(self.device, &mut version as *mut Struct_bladerf_version);
+			let res = bladerf_fw_version(
+				self.device.assume_init(),
+				&mut version
+			);
 
 			handle_res!(res, version);
 		}
@@ -177,7 +194,7 @@ impl BladeRFDevice {
 
 	pub fn is_fpga_configured(&self) -> Result<bool, isize> {
 		unsafe {
-			let res = bladerf_is_fpga_configured(self.device);
+			let res = bladerf_is_fpga_configured(self.device.assume_init());
 
 			if res > 0 {
 				Ok(true)
@@ -191,27 +208,25 @@ impl BladeRFDevice {
 
 	pub fn fpga_version(&self) -> Result<Struct_bladerf_version, isize> {
 		unsafe {
-			let mut version: Struct_bladerf_version = mem::uninitialized();
+			let mut version = Struct_bladerf_version {
+				major: 0,
+				minor: 0,
+				patch: 0,
+				describe: 0 as *const i8,
+			};			
 
-			let res = bladerf_fpga_version(self.device, &mut version as *mut Struct_bladerf_version);
+			let res = bladerf_fpga_version(self.device.assume_init(), &mut version);
 
 			handle_res!(res, version);
 		}
 	}
-
-	pub fn close(&self) {
-		unsafe {
-			bladerf_close(self.device)
-		}
-	}
-
 
 	// RX & TX Module Control
 	// http://www.nuand.com/libbladeRF-doc/v1.7.2/group___f_n___m_o_d_u_l_e.html
 
 	pub fn enable_module(&self, module: bladerf_module, enable: bool) -> Result<isize, isize> {
 		unsafe {
-			let res = bladerf_enable_module(self.device, module, enable as u8);
+			let res = bladerf_enable_module(self.device.assume_init(), module, enable as u8);
 
 			handle_res!(res);
 		}
@@ -223,7 +238,7 @@ impl BladeRFDevice {
 
 	pub fn set_lna_gain(&self, gain: bladerf_lna_gain) -> Result<isize, isize> {
 		unsafe {
-			let res = bladerf_set_lna_gain(self.device, gain);
+			let res = bladerf_set_lna_gain(self.device.assume_init(), gain);
 
 			handle_res!(res);
 		}
@@ -233,7 +248,7 @@ impl BladeRFDevice {
 		unsafe {
 			let mut gain: bladerf_lna_gain = bladerf_lna_gain::BLADERF_LNA_GAIN_UNKNOWN;
 
-			let res = bladerf_get_lna_gain(self.device, &mut gain as *mut bladerf_lna_gain); 
+			let res = bladerf_get_lna_gain(self.device.assume_init(), &mut gain); 
 
 			handle_res!(res, gain);
 		}
@@ -241,7 +256,7 @@ impl BladeRFDevice {
 
 	pub fn set_rxvga1(&self, gain: i32) -> Result<isize, isize> {
 		unsafe {
-			let res = bladerf_set_rxvga1(self.device, gain);
+			let res = bladerf_set_rxvga1(self.device.assume_init(), gain);
 
 			handle_res!(res);
 		}
@@ -251,7 +266,7 @@ impl BladeRFDevice {
 		unsafe {
 			let mut gain: i32 = 0;
 
-			let res = bladerf_get_rxvga1(self.device, &mut gain as *mut i32); 
+			let res = bladerf_get_rxvga1(self.device.assume_init(), &mut gain); 
 
 			handle_res!(res, gain);
 		}
@@ -259,7 +274,7 @@ impl BladeRFDevice {
 
 	pub fn set_rxvga2(&self, gain: i32) -> Result<isize, isize> {
 		unsafe {
-			let res = bladerf_set_rxvga2(self.device, gain);
+			let res = bladerf_set_rxvga2(self.device.assume_init(), gain);
 
 			handle_res!(res);
 		}
@@ -269,7 +284,7 @@ impl BladeRFDevice {
 		unsafe {
 			let mut gain: i32 = 0;
 
-			let res = bladerf_get_rxvga2(self.device, &mut gain as *mut i32); 
+			let res = bladerf_get_rxvga2(self.device.assume_init(), &mut gain); 
 
 			handle_res!(res, gain);
 		}
@@ -277,7 +292,7 @@ impl BladeRFDevice {
 
 	pub fn set_txvga1(&self, gain: i32) -> Result<isize, isize> {
 		unsafe {
-			let res = bladerf_set_txvga1(self.device, gain);
+			let res = bladerf_set_txvga1(self.device.assume_init(), gain);
 
 			handle_res!(res);
 		}
@@ -287,7 +302,7 @@ impl BladeRFDevice {
 		unsafe {
 			let mut gain: i32 = 0;
 
-			let res = bladerf_get_txvga1(self.device, &mut gain as *mut i32); 
+			let res = bladerf_get_txvga1(self.device.assume_init(), &mut gain); 
 
 			handle_res!(res, gain);
 		}
@@ -295,7 +310,7 @@ impl BladeRFDevice {
 
 	pub fn set_txvga2(&self, gain: i32) -> Result<isize, isize> {
 		unsafe {
-			let res = bladerf_set_txvga2(self.device, gain);
+			let res = bladerf_set_txvga2(self.device.assume_init(), gain);
 
 			handle_res!(res);
 		}
@@ -305,7 +320,7 @@ impl BladeRFDevice {
 		unsafe {
 			let mut gain: i32 = 0;
 
-			let res = bladerf_get_txvga2(self.device, &mut gain as *mut i32); 
+			let res = bladerf_get_txvga2(self.device.assume_init(), &mut gain); 
 
 			handle_res!(res, gain);
 		}
@@ -313,7 +328,7 @@ impl BladeRFDevice {
 
 	pub fn set_gain(&self, module: bladerf_module, gain: i32) -> Result<isize, isize> {
 		unsafe {
-			let res = bladerf_set_gain(self.device, module, gain);
+			let res = bladerf_set_gain(self.device.assume_init(), module, gain);
 
 			handle_res!(res);
 		}
@@ -325,7 +340,7 @@ impl BladeRFDevice {
 		let mut actual: u32 = 0;
 
 		unsafe {
-			let res = bladerf_set_sample_rate(self.device, module, rate, &mut actual as *mut u32);
+			let res = bladerf_set_sample_rate(self.device.assume_init(), module, rate, &mut actual);
 
 			handle_res!(res, actual);
 		}
@@ -335,10 +350,16 @@ impl BladeRFDevice {
 		let mut rate = rate;
 
 		unsafe {
-			let mut actual: Struct_bladerf_rational_rate = mem::uninitialized();
+			let mut actual = Struct_bladerf_rational_rate {
+				integer: 0,
+				num: 0,
+				den: 0,
+			};
 
-			let res = bladerf_set_rational_sample_rate(self.device, module, &mut rate as *mut Struct_bladerf_rational_rate,
-														&mut actual as *mut Struct_bladerf_rational_rate);
+			let res = bladerf_set_rational_sample_rate(self.device.assume_init(),
+														module,
+														&mut rate,
+														&mut actual);
 			handle_res!(res, actual);
 		}
 	}
@@ -347,7 +368,7 @@ impl BladeRFDevice {
 		let mut rate: u32 = 0;
 
 		unsafe {
-			let res = bladerf_get_sample_rate(self.device, module, &mut rate as *mut u32);
+			let res = bladerf_get_sample_rate(self.device.assume_init(), module, &mut rate);
 
 			handle_res!(res, rate);
 		}
@@ -355,9 +376,13 @@ impl BladeRFDevice {
 
 	pub fn get_rational_sample_rate(&self, module: bladerf_module) -> Result<Struct_bladerf_rational_rate, isize> {
 		unsafe {
-			let mut rate: Struct_bladerf_rational_rate = mem::uninitialized();
+			let mut rate = Struct_bladerf_rational_rate {
+				integer: 0,
+				num: 0,
+				den: 0,
+			};
 
-			let res = bladerf_get_rational_sample_rate(self.device, module, &mut rate as *mut Struct_bladerf_rational_rate);
+			let res = bladerf_get_rational_sample_rate(self.device.assume_init(), module, &mut rate);
 			
 			handle_res!(res, rate);
 		}
@@ -365,7 +390,7 @@ impl BladeRFDevice {
 
 	pub fn set_sampling(&self, sampling: bladerf_sampling) -> Result<isize, isize> {
 		unsafe {
-			let res = bladerf_set_sampling(self.device, sampling);
+			let res = bladerf_set_sampling(self.device.assume_init(), sampling);
 
 			handle_res!(res);
 		}
@@ -394,9 +419,9 @@ impl BladeRFDevice {
 
 	pub fn get_sampling(&self) -> Result<bladerf_sampling, isize> {
 		unsafe {
-			let mut sampling: bladerf_sampling = mem::uninitialized();
+			let mut sampling = bladerf_sampling::BLADERF_SAMPLING_UNKNOWN;
 
-			let res = bladerf_get_sampling(self.device, &mut sampling as *mut bladerf_sampling);
+			let res = bladerf_get_sampling(self.device.assume_init(), &mut sampling);
 
 			handle_res!(res, sampling);
 		}
@@ -409,7 +434,7 @@ impl BladeRFDevice {
 		let mut actual: u32 = 0;
 
 		unsafe {
-			let res = bladerf_set_bandwidth(self.device, module, bandwidth, &mut actual as *mut u32);
+			let res = bladerf_set_bandwidth(self.device.assume_init(), module, bandwidth, &mut actual);
 
 			handle_res!(res, actual);
 		}
@@ -419,7 +444,7 @@ impl BladeRFDevice {
 		unsafe {
 			let mut bandwidth: u32 = 0;
 
-			let res = bladerf_get_bandwidth(self.device, module, &mut bandwidth as *mut u32);
+			let res = bladerf_get_bandwidth(self.device.assume_init(), module, &mut bandwidth);
 
 			handle_res!(res, bandwidth);
 		}
@@ -427,7 +452,7 @@ impl BladeRFDevice {
 
 	pub fn set_lpf_mode(&self, module: bladerf_module, lpf_mode: bladerf_lpf_mode) -> Result<isize, isize> {
 		unsafe {
-			let res = bladerf_set_lpf_mode(self.device, module, lpf_mode);
+			let res = bladerf_set_lpf_mode(self.device.assume_init(), module, lpf_mode);
 
 			handle_res!(res);
 		}
@@ -435,9 +460,13 @@ impl BladeRFDevice {
 
 	pub fn get_lpf_mode(&self, module: bladerf_module) -> Result<bladerf_lpf_mode, isize> {
 		unsafe {
-			let mut lpf_mode: bladerf_lpf_mode = mem::uninitialized();
+			let mut lpf_mode = bladerf_lpf_mode::BLADERF_LPF_NORMAL;
 
-			let res = bladerf_get_lpf_mode(self.device, module, &mut lpf_mode as *mut bladerf_lpf_mode);
+			let res = bladerf_get_lpf_mode(
+				self.device.assume_init(),
+				module,
+				&mut lpf_mode
+			);
 
 			handle_res!(res, lpf_mode);
 		}
@@ -453,15 +482,15 @@ impl BladeRFDevice {
 
 	pub fn select_band(&self, module: bladerf_module, frequency: u32) -> Result<isize, isize> {
 		unsafe {
-			let res = bladerf_select_band(self.device, module, frequency);
+			let res = bladerf_select_band(self.device.assume_init(), module, frequency);
 
 			handle_res!(res);
 		}
 	}
 
-	pub fn set_frequency(&self, module: bladerf_module, frequency: u32) -> Result<isize, isize> {
+	pub fn set_frequency(&self, module: bladerf_module, frequency: u64) -> Result<isize, isize> {
 		unsafe {
-			let res = bladerf_set_frequency(self.device, module, frequency);
+			let res = bladerf_set_frequency(self.device.assume_init(), module, frequency);
 
 			handle_res!(res);
 		}
@@ -485,7 +514,7 @@ impl BladeRFDevice {
 			}
 
 			// Call underlying function
-			let res = bladerf_schedule_retune(self.device, module, time, frequency, p);
+			let res = bladerf_schedule_retune(self.device.assume_init(), module, time, frequency, p);
 
 			// Process response
 			handle_res!(res)
@@ -494,17 +523,17 @@ impl BladeRFDevice {
 
 	pub fn cancel_scheduled_retune(&self, module: bladerf_module) -> Result<isize, isize> {
 		unsafe {
-			let res = bladerf_cancel_scheduled_retunes(self.device, module) as isize;
+			let res = bladerf_cancel_scheduled_retunes(self.device.assume_init(), module) as isize;
 
 			handle_res!(res);
 		}
 	}
 
-	pub fn get_frequency(&self, module: bladerf_module) -> Result<u32, isize> {
+	pub fn get_frequency(&self, module: bladerf_module) -> Result<u64, isize> {
 		unsafe {
-			let mut freq: u32 = 0;
+			let mut freq: u64 = 0;
 
-			let res = bladerf_get_frequency(self.device, module, &mut freq as *mut u32); 
+			let res = bladerf_get_frequency(self.device.assume_init(), module, &mut freq);
 
 			handle_res!(res, freq);
 		}
@@ -512,9 +541,15 @@ impl BladeRFDevice {
 
 	pub fn get_quick_tune(&self, module: bladerf_module) -> Result<Struct_bladerf_quick_tune, isize> {
 		unsafe {
-			let mut quick_tune: Struct_bladerf_quick_tune = mem::uninitialized();
+			let mut quick_tune = Struct_bladerf_quick_tune {
+				freqsel: 0,
+				vcocap: 0,
+				nint: 0,
+				nfrac: 0,
+				flags: 0,
+			};
 
-			let res = bladerf_get_quick_tune(self.device, module, &mut quick_tune as *mut Struct_bladerf_quick_tune); 
+			let res = bladerf_get_quick_tune(self.device.assume_init(), module, &mut quick_tune); 
 
 			handle_res!(res, quick_tune);
 		}
@@ -522,7 +557,7 @@ impl BladeRFDevice {
 
 	pub fn set_tuning_mode(&self, mode: bladerf_tuning_mode) -> Result<isize, isize> {
 		unsafe {
-			let res = bladerf_set_tuning_mode(self.device, mode) as isize;
+			let res = bladerf_set_tuning_mode(self.device.assume_init(), mode) as isize;
 
 			handle_res!(res);
 		}
@@ -534,7 +569,7 @@ impl BladeRFDevice {
 
 	pub fn set_loopback(&self, loopback: bladerf_loopback) -> Result<isize, isize> {
 		unsafe {
-			let res = bladerf_set_loopback(self.device, loopback); 
+			let res = bladerf_set_loopback(self.device.assume_init(), loopback); 
 
 			handle_res!(res);
 		}
@@ -542,11 +577,9 @@ impl BladeRFDevice {
 
 	pub fn get_loopback(&self) -> Result<bladerf_loopback, isize> {
 		unsafe {
-			let mut loopback: bladerf_loopback = mem::uninitialized();
-
-			let res = bladerf_get_loopback(self.device, &mut loopback as *mut bladerf_loopback); 
-
-			handle_res!(res, loopback);
+			let mut loopback = bladerf_loopback::BLADERF_LB_NONE;
+			let res = bladerf_get_loopback(self.device.assume_init(), &mut loopback);
+			handle_res!(res, loopback);			
 		}
 	}
 
@@ -586,7 +619,7 @@ impl BladeRFDevice {
 		let num_transfers = match num_transfers { Some(t) => t, None => 4};
 
 		unsafe {
-			let res = bladerf_sync_config(self.device, module, format, num_buffers, buffer_size, num_transfers, stream_timeout);
+			let res = bladerf_sync_config(self.device.assume_init(), module, format, num_buffers, buffer_size, num_transfers, stream_timeout);
 		
 			handle_res!(res);
 		}
@@ -608,7 +641,7 @@ impl BladeRFDevice {
 		let data_ptr: *mut libc::c_void = data.as_ptr() as *mut libc::c_void;
 
 		unsafe {
-			let res = bladerf_sync_tx(self.device, data_ptr, data.len() as u32, meta_ptr, stream_timeout);
+			let res = bladerf_sync_tx(self.device.assume_init(), data_ptr, data.len() as u32, meta_ptr, stream_timeout);
 		
 			handle_res!(res);
 		}
@@ -630,7 +663,7 @@ impl BladeRFDevice {
 		let data_ptr: *mut libc::c_void = data.as_ptr() as *mut libc::c_void;
 
 		unsafe {
-			let res = bladerf_sync_rx(self.device, data_ptr, data.len() as u32, meta_ptr, stream_timeout);
+			let res = bladerf_sync_rx(self.device.assume_init(), data_ptr, data.len() as u32, meta_ptr, stream_timeout);
 		
 			handle_res!(res);
 		}
@@ -642,7 +675,7 @@ impl BladeRFDevice {
 		let c_string = ffi::CString::new(file.into_bytes()).unwrap();
 
 		unsafe {
-			let res = bladerf_load_fpga(self.device, c_string.as_ptr());
+			let res = bladerf_load_fpga(self.device.assume_init(), c_string.as_ptr());
 
 			handle_res!(res)
 		}
@@ -691,16 +724,14 @@ mod tests {
 
 	#[test]
 	fn test_open() {
-		let device = super::open(None).unwrap();
-		device.close();
+		let _device = super::open(None).unwrap();
 	}
 
 	#[test]
 	fn test_open_devinfo() {
 		let devices = super::get_device_list().unwrap();
 		assert!(devices.len() != 0);
-		let device = super::open_with_devinfo(&devices[0]).unwrap();
-		device.close();
+		let _device = super::open_with_devinfo(&devices[0]).unwrap();
 	}
 
 	#[test]
@@ -709,8 +740,6 @@ mod tests {
 
 		let version = device.fw_version().unwrap();
 		println!("FW Version {:?}", version);
-
-		device.close();
 	}
 
 	#[test]
@@ -719,8 +748,6 @@ mod tests {
 
 		let version = device.fpga_version().unwrap();
 		println!("FPGA Version {:?}", version);
-
-		device.close();
 	}
 
 	#[test]
@@ -730,8 +757,6 @@ mod tests {
 		let serial = device.get_serial().unwrap();
 		println!("Serial: {:?}", serial);
 		assert!(serial.len() == 33);
-
-		device.close();
 	}
 
 	#[test]
@@ -740,8 +765,6 @@ mod tests {
 		
 		let loaded = device.is_fpga_configured().unwrap();
 		assert_eq!(true, loaded);
-
-		device.close();
 	}
 
 	#[test]
@@ -760,22 +783,21 @@ mod tests {
 		// Reset
 		device.set_loopback(bladerf_loopback::BLADERF_LB_NONE).unwrap();
 
-		device.close();
+		let loopback = device.get_loopback().unwrap();
+		assert!(loopback == bladerf_loopback::BLADERF_LB_NONE);
 	}
 
 	#[test]
 	fn test_set_freq() {
 		let device = super::open(None).unwrap();
 
-		let freq: u32 = 915000000;
+		let freq: u64 = 915000000;
 
 		// Set and check frequency
 		device.set_frequency(bladerf_module::BLADERF_MODULE_RX, freq).unwrap();
-
 		let actual_freq = device.get_frequency(bladerf_module::BLADERF_MODULE_RX).unwrap();
-		assert!(actual_freq == freq);
-
-		device.close();
+		let diff = freq as i64 - actual_freq as i64;
+		assert!(i64::abs(diff) < 10);
 	}
 
 	#[test]
@@ -785,11 +807,17 @@ mod tests {
 		let sampling: bladerf_sampling = bladerf_sampling::BLADERF_SAMPLING_INTERNAL;
 
 		// Set and check frequency
-		device.set_sampling(sampling).unwrap();
+		match device.set_sampling(sampling) {
+			Ok(_) => (),
+			Err(err) => if err != -8 {
+				panic!("unexpected error of value when calling set_sampling {:?}", err);
+			} else {
+				return;				
+			}
+		};
 
 		let actual_sampling = device.get_sampling().unwrap();
-		assert!(actual_sampling == sampling);
 
-		device.close();
+		assert!(actual_sampling == sampling);
 	}
 }


### PR DESCRIPTION
Lot of changes but mostly minor.
Updated functions like `sync_config` to support the newer boards.
Fixed all of the `mem::uninitialized` warnings.
Added `Sync` and `Send` so it can be used in multiple threads.
Shortened the enums.
Fixed a bug in set_frequency and get_frequency where u32 was used instead of u64.
Moved `close` method to `Drop` implementation for safer usage.
Updated the test cases.