### PR TITLE
A few fixes, additions, and some minor changes.

### DIFF
--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -461,8 +461,13 @@ extern "C" {
      -> ::libc::c_int;
     pub fn bladerf_get_bandwidth(dev: *mut Struct_bladerf,
                                  module: bladerf_module,
-                                 bandwidth: *mut ::libc::c_uint)
-     -> ::libc::c_int;
+                                 bandwidth: *mut ::libc::c_uint) -> ::libc::c_int;
+    pub fn bladerf_get_bias_tee(dev: *mut Struct_bladerf,
+                                module: bladerf_module,
+                                enable: *mut bool) -> ::libc::c_int;
+    pub fn bladerf_set_bias_tee(dev: *mut Struct_bladerf,
+                                module: bladerf_module,
+                                enable: bool) -> ::libc::c_int;
     pub fn bladerf_set_lpf_mode(dev: *mut Struct_bladerf,
                                 module: bladerf_module,
                                 mode: bladerf_lpf_mode) -> ::libc::c_int;

--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -221,8 +221,27 @@ pub enum bladerf_error {
     WOULD_BLOCK = -18,
 }
 
+pub enum bladerf_meta {
+    STATUS_OVERRUN = 1,
+    STATUS_UNDERUN = 2,
+    FLAG_HW_MINIEXP1 = 65536,
+    FLAG_HW_MINIEXP2 = 131072,
+}
+
+pub enum bladerf_meta_tx {
+    FLAG_TX_BURST_START = 1,
+    FLAG_TX_BURST_END = 2,
+    FLAG_TX_NOW = 4,
+    FLAG_TX_UPDATE_TIMESTAMP = 8,
+}
+
+pub enum bladerf_meta_rx {
+    FLAG_RX_NOW = 2147483648,
+    FLAG_RX_HW_UNDERFLOW = 1,
+}
+
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Clone)]
 pub struct Struct_bladerf_metadata {
     pub timestamp: uint64_t,
     pub flags: uint32_t,
@@ -230,9 +249,7 @@ pub struct Struct_bladerf_metadata {
     pub actual_count: ::libc::c_uint,
     pub reserved: [uint8_t; 32usize],
 }
-impl ::std::clone::Clone for Struct_bladerf_metadata {
-    fn clone(&self) -> Self { *self }
-}
+
 impl ::std::default::Default for Struct_bladerf_metadata {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }

--- a/src/bladerf.rs
+++ b/src/bladerf.rs
@@ -34,6 +34,8 @@ pub struct Struct_bladerf_devinfo {
     pub usb_bus: uint8_t,
     pub usb_addr: uint8_t,
     pub instance: ::libc::c_uint,
+    pub manufacturer: [::libc::c_char; 33],
+    pub product: [::libc::c_char; 33],
 }
 impl ::std::clone::Clone for Struct_bladerf_devinfo {
     fn clone(&self) -> Self { *self }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,18 +115,16 @@ pub fn set_usb_reset_on_open(enabled: bool) {
 
 pub fn open(identifier: Option<String>) -> Result<BladeRFDevice, isize> {
 	unsafe {
-		let id_ptr = match identifier {
-			Some(id) => {
-				let c_string = ffi::CString::new(id.into_bytes()).unwrap();
-				c_string.as_ptr()
-			}, None => {
-				ptr::null()
-			}
-		};
-
 		let mut bladerf_device = BladeRFDevice { device: MaybeUninit::uninit() };
 
-		let res = bladerf_open(bladerf_device.device.as_mut_ptr(), id_ptr);
+		
+		let res = match identifier {
+			Some(id) => {
+				let c_string = ffi::CString::new(id).unwrap();
+				bladerf_open(bladerf_device.device.as_mut_ptr(), c_string.as_ptr())
+			},
+			None => bladerf_open(bladerf_device.device.as_mut_ptr(), ptr::null()),
+		};
 
 		handle_res!(res, bladerf_device);
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -833,18 +833,18 @@ mod tests {
 
 		// Check initial is none
 		let loopback = device.get_loopback().unwrap();
-		assert!(loopback == bladerf_loopback::BLADERF_LB_NONE);
+		assert!(loopback == bladerf_loopback::NONE);
 
 		// Set and check loopback modes
-		device.set_loopback(bladerf_loopback::BLADERF_LB_FIRMWARE).unwrap();
+		device.set_loopback(bladerf_loopback::FIRMWARE).unwrap();
 		let loopback = device.get_loopback().unwrap();
-		assert!(loopback == bladerf_loopback::BLADERF_LB_FIRMWARE);
+		assert!(loopback == bladerf_loopback::FIRMWARE);
 
 		// Reset
-		device.set_loopback(bladerf_loopback::BLADERF_LB_NONE).unwrap();
+		device.set_loopback(bladerf_loopback::NONE).unwrap();
 
 		let loopback = device.get_loopback().unwrap();
-		assert!(loopback == bladerf_loopback::BLADERF_LB_NONE);
+		assert!(loopback == bladerf_loopback::NONE);
 	}
 
 	#[test]
@@ -854,8 +854,8 @@ mod tests {
 		let freq: u64 = 915000000;
 
 		// Set and check frequency
-		device.set_frequency(bladerf_module::BLADERF_MODULE_RX, freq).unwrap();
-		let actual_freq = device.get_frequency(bladerf_module::BLADERF_MODULE_RX).unwrap();
+		device.set_frequency(bladerf_module::RX0, freq).unwrap();
+		let actual_freq = device.get_frequency(bladerf_module::RX0).unwrap();
 		let diff = freq as i64 - actual_freq as i64;
 		assert!(i64::abs(diff) < 10);
 	}
@@ -864,7 +864,7 @@ mod tests {
 	fn test_set_sampling() {
 		let device = super::open(None).unwrap();
 
-		let sampling: bladerf_sampling = bladerf_sampling::BLADERF_SAMPLING_INTERNAL;
+		let sampling: bladerf_sampling = bladerf_sampling::INTERNAL;
 
 		// Set and check frequency
 		match device.set_sampling(sampling) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,10 @@ pub use bladerf::*;
 pub use bladerf::bladerf_module;
 pub use bladerf::bladerf_channel_layout;
 pub use bladerf::bladerf_format;
+pub use bladerf::Struct_bladerf_metadata;
+pub use bladerf::bladerf_meta;
+pub use bladerf::bladerf_meta_rx;
+pub use bladerf::bladerf_meta_tx;
 
 // Macro to simplify integer returns
 macro_rules! handle_res {
@@ -641,47 +645,72 @@ impl BladeRFDevice {
 		}
 	}
 
-	pub fn sync_tx(&self, data: &Vec<Complex<i16>>, meta: Option<Struct_bladerf_metadata>, stream_timeout: u32)
+	pub fn sync_tx_meta(&self, data: &Vec<Complex<i16>>, meta: &mut Struct_bladerf_metadata, stream_timeout: u32)
 		       -> Result<isize, isize> {
-
-		// Handle optional meta argument
-		let meta_ptr: *mut Struct_bladerf_metadata = match meta { 
-			Some(m) => {
-				let mut meta_int = m;
-				&mut meta_int
-			}, None => {
-				ptr::null_mut()
-			}
-		};
 
 		let data_ptr: *mut libc::c_void = data.as_ptr() as *mut libc::c_void;
 
 		unsafe {
-			let res = bladerf_sync_tx(self.device.assume_init(), data_ptr, data.len() as u32, meta_ptr, stream_timeout);
+			let res = bladerf_sync_tx(
+				self.device.assume_init(),
+				data_ptr,
+				data.len() as u32,
+				meta as *mut Struct_bladerf_metadata,
+				stream_timeout
+			);
 		
 			handle_res!(res);
 		}
-	}
+	}	
 
-	pub fn sync_rx(&self, data: &mut [Complex<i16>], meta: Option<Struct_bladerf_metadata>, stream_timeout: u32)
+	pub fn sync_tx(&self, data: &Vec<Complex<i16>>, stream_timeout: u32)
 		       -> Result<isize, isize> {
-
-		// Handle optional meta argument
-		let meta_ptr: *mut Struct_bladerf_metadata = match meta { 
-			Some(m) => {
-				let mut meta_int = m;
-				&mut meta_int
-			}, None => {
-				ptr::null_mut()
-			}
-		};
 
 		let data_ptr: *mut libc::c_void = data.as_ptr() as *mut libc::c_void;
 
 		unsafe {
-			let res = bladerf_sync_rx(self.device.assume_init(), data_ptr, data.len() as u32, meta_ptr, stream_timeout);
+			let res = bladerf_sync_tx(
+				self.device.assume_init(),
+				data_ptr, data.len() as u32,
+				ptr::null_mut(),
+				stream_timeout
+			);
 		
-			handle_res!(res);
+			handle_res!(res)
+		}
+	}
+
+	pub fn sync_rx_meta(&self, data: &mut [Complex<i16>], meta: &mut Struct_bladerf_metadata, stream_timeout: u32)
+		       -> Result<isize, isize> {
+		let data_ptr: *mut libc::c_void = data.as_ptr() as *mut libc::c_void;
+
+		unsafe {
+			let res = bladerf_sync_rx(
+				self.device.assume_init(),
+				data_ptr,
+				data.len() as u32,
+				meta as *mut Struct_bladerf_metadata,
+				stream_timeout
+			);
+		
+			handle_res!(res)
+		}
+	}	
+
+	pub fn sync_rx(&self, data: &mut [Complex<i16>], stream_timeout: u32)
+		       -> Result<isize, isize> {
+		let data_ptr: *mut libc::c_void = data.as_ptr() as *mut libc::c_void;
+
+		unsafe {
+			let res = bladerf_sync_rx(
+				self.device.assume_init(),
+				data_ptr,
+				data.len() as u32,
+				ptr::null_mut(),
+				stream_timeout
+			);
+		
+			handle_res!(res)
 		}
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -663,7 +663,7 @@ impl BladeRFDevice {
 		}
 	}
 
-	pub fn sync_rx(&self, data: &mut Vec<Complex<i16>>, meta: Option<Struct_bladerf_metadata>, stream_timeout: u32)
+	pub fn sync_rx(&self, data: &mut [Complex<i16>], meta: Option<Struct_bladerf_metadata>, stream_timeout: u32)
 		       -> Result<isize, isize> {
 
 		// Handle optional meta argument

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,7 +652,7 @@ impl BladeRFDevice {
 		value
 	}
 
-	pub fn sync_tx_meta(&self, data: &Vec<Complex<i16>>, meta: &mut Struct_bladerf_metadata, stream_timeout: u32)
+	pub fn sync_tx_meta(&self, data: &[Complex<i16>], meta: &mut Struct_bladerf_metadata, stream_timeout: u32)
 		       -> Result<isize, isize> {
 
 		let data_ptr: *mut libc::c_void = data.as_ptr() as *mut libc::c_void;
@@ -670,7 +670,7 @@ impl BladeRFDevice {
 		}
 	}	
 
-	pub fn sync_tx(&self, data: &Vec<Complex<i16>>, stream_timeout: u32)
+	pub fn sync_tx(&self, data: &[Complex<i16>], stream_timeout: u32)
 		       -> Result<isize, isize> {
 
 		let data_ptr: *mut libc::c_void = data.as_ptr() as *mut libc::c_void;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -733,6 +733,29 @@ impl BladeRFDevice {
 		}
 	}
 
+	/*
+    pub fn bladerf_get_bias_tee(dev: *mut Struct_bladerf,
+		module: bladerf_module,
+		enable: *mut bool) -> ::libc::c_int;
+	pub fn bladerf_set_bias_tee(dev: *mut Struct_bladerf,
+			module: bladerf_module,
+			enable: bool) -> ::libc::c_int;
+	*/
+
+	pub fn get_bias_tee(&self, module: bladerf_module) -> Result<bool, isize>  {
+		unsafe {
+			let mut value = false;
+			let res = bladerf_get_bias_tee(self.device.assume_init(), module, &mut value);
+			handle_res!(res, value)
+		}
+	}
+
+	pub fn set_bias_tee(&self, module: bladerf_module, enable: bool) -> Result<isize, isize> {
+		unsafe {
+			let res = bladerf_set_bias_tee(self.device.assume_init(), module, enable);
+			handle_res!(res)
+		}
+	}	
 
 	// Higher level control
 	pub fn configure_module(&self, module: bladerf_module, config: BladeRFModuleConfig) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,6 +645,15 @@ impl BladeRFDevice {
 		}
 	}
 
+	pub fn get_timestamp(&self, module: bladerf_module) -> u64 {
+		let mut value = 0u64;
+		unsafe {
+			bladerf_get_timestamp(self.device.assume_init(), module, &mut value as *mut u64);
+		}
+
+		value
+	}
+
 	pub fn sync_tx_meta(&self, data: &Vec<Complex<i16>>, meta: &mut Struct_bladerf_metadata, stream_timeout: u32)
 		       -> Result<isize, isize> {
 


### PR DESCRIPTION
Split bladerf_meta into three enums because of overlapping values.
Removed copy from Struct_bladerf_metadata to prevent accidental copying.
Fixed bladerf::open issue with ffi::CString being released before use.
Added get_timestamp.
Made sync_rx/sync_tx seperate from sync_rx_meta/sync_tx_meta.
Replaced Vec<Complex<i16>> with slice in sync_rx/sync_tx family of methods.
Fixed tests and struct_bladerf_deviceinfo.
Fixed tests not compiling. Added missing fields in Struct_bladerf_deviceinfo.